### PR TITLE
Support for dateext option

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -156,6 +156,11 @@ _EOF_
   ${logrotate_size}
 _EOF_
         fi
+        if [ -n "${LOGROTATE_DATEEXT}" ]; then
+          cat >> /usr/bin/logrotate.d/logrotate.conf <<_EOF_
+  dateext
+_EOF_
+        fi
         cat >> /usr/bin/logrotate.d/logrotate.conf <<_EOF_
 }
 _EOF_
@@ -210,6 +215,11 @@ _EOF_
         if [ -n "${logrotate_size}" ]; then
           cat >> /usr/bin/logrotate.d/logrotate.conf <<_EOF_
   ${logrotate_size}
+_EOF_
+        fi
+        if [ -n "${LOGROTATE_DATEEXT}" ]; then
+          cat >> /usr/bin/logrotate.d/logrotate.conf <<_EOF_
+  dateext
 _EOF_
         fi
         cat >> /usr/bin/logrotate.d/logrotate.conf <<_EOF_


### PR DESCRIPTION
I just needed a way to get the date in the file extension.

This way the environment `LOGROTATE_DATEEXT` can be set to anything.

Tested and appears to be working alongside `daily`