### PR TITLE
Allow definition of date extension + README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,26 @@ $ docker run -d \
 > You will be able to see cron output every minute in file logs/cron.log
 
 
+# Setting a Date Extension
+
+With Logrotate it is possible to split files and name them by the date they were generated when used with `LOGROTATE_CRONSCHEDULE`. By setting `LOGROTATE_DATEFORMAT` you will enable the Logrotate `dateext` option.
+
+The default Logrotate format is `-%Y%m%d`, to enable the defaults `LOGROTATE_DATEFORMAT` should be set to this.
+
+Example:
+
+~~~~
+$ docker run -d \
+  -v /var/lib/docker/containers:/var/lib/docker/containers \
+  -v /var/log/docker:/var/log/docker \
+  -e "LOGROTATE_INTERVAL=daily" \
+  -e "LOGROTATE_CRONSCHEDULE=0 * * * * *" \
+  -e "LOGS_DIRECTORIES=/var/lib/docker/containers /var/log/docker" \
+  -e "LOGROTATE_DATEFORMAT=-%Y%m%d" \
+  blacklabelops/logrotate
+~~~~
+
+
 ## Vagrant
 
 Vagrant is fabulous tool for pulling and spinning up virtual machines like docker with containers. I can configure my development and test environment and simply pull it online. And so can you! Install Vagrant and Virtualbox and spin it up. Change into the project folder and build the project on the spot!

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -156,9 +156,10 @@ _EOF_
   ${logrotate_size}
 _EOF_
         fi
-        if [ -n "${LOGROTATE_DATEEXT}" ]; then
+        if [ -n "${LOGROTATE_DATEFORMAT}" ]; then
           cat >> /usr/bin/logrotate.d/logrotate.conf <<_EOF_
   dateext
+  dateformat ${LOGROTATE_DATEFORMAT}
 _EOF_
         fi
         cat >> /usr/bin/logrotate.d/logrotate.conf <<_EOF_
@@ -217,9 +218,10 @@ _EOF_
   ${logrotate_size}
 _EOF_
         fi
-        if [ -n "${LOGROTATE_DATEEXT}" ]; then
+        if [ -n "${LOGROTATE_DATEFORMAT}" ]; then
           cat >> /usr/bin/logrotate.d/logrotate.conf <<_EOF_
   dateext
+  dateformat ${LOGROTATE_DATEFORMAT}
 _EOF_
         fi
         cat >> /usr/bin/logrotate.d/logrotate.conf <<_EOF_


### PR DESCRIPTION
Further to #3 I have removed the ambiguous DATEEXT variable and replaced it with a DATEFORMAT one which takes input and will add dateext when defined.

I have added in some documentation for this also. 

I'm fairly sure this will work as it generates the logrotate config as I expect. I will give you an update tomorrow to see if it works as expected.