### PR TITLE
add update-logrotate.sh, implement feature to ensure /usr/bin/logrotate.d/logrotate.conf's configuration is kept update to date with log directories' log files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,8 @@ ENV LOGROTATE_OLDDIR= \
     LOG_FILE=
 
 COPY docker-entrypoint.sh /usr/bin/logrotate.d/docker-entrypoint.sh
+COPY update-logrotate.sh /usr/bin/logrotate.d/update-logrotate.sh
+
 ENTRYPOINT ["/usr/bin/logrotate.d/docker-entrypoint.sh"]
 VOLUME ["/logrotate-status"]
 CMD ["cron"]

--- a/README.md
+++ b/README.md
@@ -292,6 +292,23 @@ $ docker run -d \
   blacklabelops/logrotate
 ~~~~
 
+# Disable Auto Update
+
+With Logrotate by default it auto update its logrotate configuration file to ensure it only captures all the intended log file in the `LOGS_DIRECTORIES` (before it rotates the log files). It is possible to disable auto update when used with `LOGROTATE_AUTOUPDATE`. By setting `LOGROTATE_AUTOUPDATE` (to not equal true) you will disable the auto update of Logrotate.
+
+The default `LOGROTATE_AUTOUPDATE` is `true`, to disable the defaults `LOGROTATE_AUTOUPDATE` should be set not equal `true`.
+
+Example:
+
+~~~~
+docker run -d \
+	-v /var/lib/docker/containers:/var/lib/docker/containers \
+	-v /var/log/docker:/var/log/docker \
+	-e "LOGS_DIRECTORIES=/var/lib/docker/containers /var/log/docker" \
+  -e "LOGROTATE_AUTOUPDATE=false" \
+  blacklabelops/logrotate
+~~~~
+
 
 ## Vagrant
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -78,6 +78,12 @@ if [ -n "${LOGROTATE_SIZE}" ]; then
   logrotate_size="size "${LOGROTATE_SIZE}
 fi
 
+logrotate_autoupdate=true
+
+if [ -n "${LOGROTATE_AUTOUPDATE}" ]; then
+  logrotate_autoupdate="$(echo ${LOGROTATE_AUTOUPDATE,,})"
+fi
+
 touch /usr/bin/logrotate.d/logrotate.conf
 
 cat >> /usr/bin/logrotate.d/logrotate.conf <<EOF
@@ -265,7 +271,12 @@ logrotate_cron_timetable="/usr/sbin/logrotate ${logrotate_parameters} --state=${
 # ----- Cron Start ------
 
 if [ "$1" = 'cron' ]; then
-  /usr/bin/go-cron "${logrotate_croninterval}" /bin/bash -c "/usr/bin/logrotate.d/update-logrotate.sh; ${logrotate_cron_timetable}"
+  if [ ${logrotate_autoupdate} = "true" ]; then
+    /usr/bin/go-cron "${logrotate_croninterval}" /bin/bash -c "/usr/bin/logrotate.d/update-logrotate.sh; ${logrotate_cron_timetable}"
+    exit
+  fi
+
+  /usr/bin/go-cron "${logrotate_croninterval}" /bin/bash -c "${logrotate_cron_timetable}"
 fi
 
 #-----------------------

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -265,7 +265,7 @@ logrotate_cron_timetable="/usr/sbin/logrotate ${logrotate_parameters} --state=${
 # ----- Cron Start ------
 
 if [ "$1" = 'cron' ]; then
-  /usr/bin/go-cron "${logrotate_croninterval}" /bin/bash -c "${logrotate_cron_timetable}"
+  /usr/bin/go-cron "${logrotate_croninterval}" /bin/bash -c "/usr/bin/logrotate.d/update-logrotate.sh; ${logrotate_cron_timetable}"
 fi
 
 #-----------------------

--- a/update-logrotate.sh
+++ b/update-logrotate.sh
@@ -71,7 +71,7 @@ function insertInOrder()
 
   if [[ $line -lt `cat $file | wc -l` ]]; then
     new_config=$(awk -v n=$line -v config="$config" 'NR == n {print config} {print}' $file)
-    echo "$new_config" | $file > /dev/null
+    echo "$new_config" | tee $file > /dev/null
   else
     echo -e "$config" | tee -a $file > /dev/null
   fi
@@ -221,7 +221,7 @@ do
           new_log="${new_log}\n}"
           echo "Inserting new ${f} in alphabetic order to /usr/bin/logratate.d/logrotate.conf"
 
-          insertInOrder $new_log $log_files /usr/bin/logrotate.d/logrotate.conf $last_line_no $d ${_i}
+          insertInOrder "$new_log" "$log_files" /usr/bin/logrotate.d/logrotate.conf $last_line_no $d ${_i}
         else
           output "File has unknown user or group: ${f}, user: ${file_owner_user}, group: ${file_owner_group}"
         fi
@@ -297,7 +297,7 @@ do
           new_log="${new_log}\n}"
           echo "Inserting new ${f} in alphabetic order to /usr/bin/logratate.d/logrotate.conf"
 
-          insertInOrder $new_log $log_files /usr/bin/logrotate.d/logrotate.conf $last_line_no $d ${_i}
+          insertInOrder "$new_log" "$log_files" /usr/bin/logrotate.d/logrotate.conf $last_line_no $d ${_i}
         else
           output "File has unknown user or group: ${f}, user: ${file_owner_user}, group: ${file_owner_group}"
         fi

--- a/update-logrotate.sh
+++ b/update-logrotate.sh
@@ -221,7 +221,7 @@ do
           new_log="${new_log}\n}"
           echo "Inserting new ${f} in alphabetic order to /usr/bin/logratate.d/logrotate.conf"
 
-          insertInOrder $new_log $log_files /usr/bin/logrotate.d/logrotate.conf $last_line_no $d $_i
+          insertInOrder $new_log $log_files /usr/bin/logrotate.d/logrotate.conf $last_line_no $d ${_i}
         else
           output "File has unknown user or group: ${f}, user: ${file_owner_user}, group: ${file_owner_group}"
         fi
@@ -297,7 +297,7 @@ do
           new_log="${new_log}\n}"
           echo "Inserting new ${f} in alphabetic order to /usr/bin/logratate.d/logrotate.conf"
 
-          insertInOrder $new_log $log_files /usr/bin/logrotate.d/logrotate.conf $last_line_no $d $_i
+          insertInOrder $new_log $log_files /usr/bin/logrotate.d/logrotate.conf $last_line_no $d ${_i}
         else
           output "File has unknown user or group: ${f}, user: ${file_owner_user}, group: ${file_owner_group}"
         fi

--- a/update-logrotate.sh
+++ b/update-logrotate.sh
@@ -1,0 +1,327 @@
+#!/bin/bash
+#
+# A helper script for updating the /usr/bin/logrotate.d/logrotate.conf.
+
+syslogger_tag=""
+
+if [ -n "${SYSLOGGER_TAG}" ]; then
+  syslogger_tag=" -t "${SYSLOGGER_TAG}
+fi
+
+syslogger_command=""
+
+if [ -n "${SYSLOGGER}" ]; then
+  syslogger_command="logger "${syslogger_tag}
+fi
+
+function output()
+{
+  if [ -n "${SYSLOGGER}" ]; then
+    logger ${syslogger_tag} "$@"
+  fi
+  echo "$@"
+}
+
+function insertInOrder()
+{
+  config=$1
+  order=$2
+  file=$3
+  begin=$4
+  directory=$5
+  _i=$6
+
+  order_arr=($order)
+
+  files=$(grep -n -E "^\s*${directory}.*\{\s*$" $file)
+
+  len=$(echo "${files}" | wc -l)
+  if [ ! "$files" ]; then
+    len=0
+  fi
+  unset files_table
+  files_table=(${files//:/ })
+  unset line
+
+  for i in `seq 0 $(( len - 1 ))`; do
+    index=$(( $i * 3 + 1 ))
+    if [[ "${order_arr[@]:${_i}}" =~ "${files_table[$index]}" ]]; then
+      line=${files_table[$(( $i * 3 ))]}
+      break
+    fi
+  done
+
+  if [[ $len -gt 0 ]]; then
+    if [ ! "$line" ]; then
+      # insert at available entry after last log path in "${files_table}"
+      last_file=${files_table[$(((len - 1)*3 + 1))]}
+      last_file=${last_file//\//\\/}
+      line_info=$(awk "
+        BEGIN {}
+          /^ *${last_file} *\{ *$/ {banner = 1; printf NR \" \"; print; next}
+          /^ *} *$/ {if (banner) {printf NR \" \"; print}; banner = 0}
+          {if (banner) {printf NR \" \"; print }}
+        END {}
+      " $file)
+      line=$(($(echo "${line_info}" | tail -n 1 | cut -f1 -d' ') + 1))
+    fi
+  else
+    line=$begin
+  fi
+
+  if [[ $line -lt `cat $file | wc -l` ]]; then
+    new_config=$(awk -v n=$line -v config="$config" 'NR == n {print config} {print}' $file)
+    echo "$new_config" | $file > /dev/null
+  else
+    echo -e "$config" | tee -a $file > /dev/null
+  fi
+}
+
+function remove() {
+  f=$1
+  file=$2
+  _f=${f//\//\\/}
+
+  new_config=$(awk "
+    BEGIN {}
+    /^ *${_f} *\{ *$/ {found=1; next}
+    /^ *\/.*\{$/ {found=0}
+    { if (! found) {print} }
+    END {}
+  " $file)
+  echo "$new_config" | tee $file > /dev/null
+}
+
+# Logrotate status file handling
+
+logrotate_logstatus="/logrotate-status/logrotate.status"
+
+if [ -n "${LOGROTATE_STATUSFILE}" ]; then
+  logrotate_logstatus=${LOGROTATE_STATUSFILE}
+fi
+
+# ----- Logrotate Config File Generation ------
+
+logrotate_olddir=""
+
+if [ -n "${LOGROTATE_OLDDIR}" ]; then
+  logrotate_olddir="olddir "${LOGROTATE_OLDDIR}
+fi
+
+# if configuration file doesn't exist, create one
+if [ ! -f /usr/bin/logrotate.d/logrotate.conf ]; then
+  touch /usr/bin/logrotate.d/logrotate.conf
+
+  cat >> /usr/bin/logrotate.d/logrotate.conf <<EOF
+# deactivate mail
+mail nomail
+
+# move the log files to another directory?
+${logrotate_olddir}
+
+EOF
+fi
+
+logrotate_logfile_compression="nocompress"
+logrotate_logfile_compression_delay=""
+
+if [ -n "${LOGROTATE_COMPRESSION}" ]; then
+  logrotate_logfile_compression=${LOGROTATE_COMPRESSION}
+  if [ ! "${logrotate_logfile_compression}" = "nocompress" ]; then
+    logrotate_logfile_compression_delay="delaycompress"
+  fi
+fi
+
+logrotate_interval=""
+
+if [ -n "${LOGROTATE_INTERVAL}" ]; then
+  logrotate_interval=${LOGROTATE_INTERVAL}
+fi
+
+logrotate_copies="5"
+
+if [ -n "${LOGROTATE_COPIES}" ]; then
+  logrotate_copies=${LOGROTATE_COPIES}
+fi
+
+logrotate_size=""
+
+if [ -n "${LOGROTATE_SIZE}" ]; then
+  logrotate_size="size "${LOGROTATE_SIZE}
+fi
+
+# ----- Logfile Crawling ------
+
+log_dirs=""
+
+if [ -n "${LOGS_DIRECTORIES}" ]; then
+  log_dirs=${LOGS_DIRECTORIES}
+else
+  log_dirs=${log_dir}
+fi
+
+logs_ending="log"
+LOGS_FILE_ENDINGS_INSTRUCTION=""
+
+if [ -n "${LOG_FILE_ENDINGS}" ]; then
+  logs_ending=${LOG_FILE_ENDINGS}
+fi
+
+SAVEIFS=$IFS
+IFS=' '
+COUNTER=0
+for ending in $logs_ending
+do
+  if [ "$COUNTER" -eq "0" ]; then
+    LOGS_FILE_ENDINGS_INSTRUCTION="$LOGS_FILE_ENDINGS_INSTRUCTION -iname "*.${ending}""
+  else
+    LOGS_FILE_ENDINGS_INSTRUCTION="$LOGS_FILE_ENDINGS_INSTRUCTION -o -iname "*.${ending}""
+  fi
+  let COUNTER=COUNTER+1
+done
+IFS=$SAVEIFS
+
+last_line_no=$(cat /usr/bin/logrotate.d/logrotate.conf | wc -l)
+for d in ${log_dirs}
+do
+  unset _d
+  _d=${_d//\//\\/}
+  _i=-1
+  log_files=$(find ${d} -type f $LOGS_FILE_ENDINGS_INSTRUCTION)
+  for f in ${log_files};
+  do
+    ((_i++))
+    if [ -f "${f}" ]; then
+      if ! grep -q -E "^\s*${f}\s*\{\s*$" /usr/bin/logrotate.d/logrotate.conf; then
+        output "Found new file $f, Processing..."
+        file_owner_user=$(stat -c %U ${f})
+        file_owner_group=$(stat -c %G ${f})
+        if [ "$file_owner_user" != "UNKNOWN" ] && [ "$file_owner_group" != "UNKNOWN" ]; then
+          unset new_log
+          new_log="${f} {"
+          new_log="${new_log}\n  su ${file_owner_user} ${file_owner_group}"
+          new_log="${new_log}\n  copytruncate"
+          new_log="${new_log}\n  rotate ${logrotate_copies}"
+          new_log="${new_log}\n  missingok"
+          if [ -n "${logrotate_logfile_compression}" ]; then
+            new_log="${new_log}\n  ${logrotate_logfile_compression}"
+          fi
+          if [ -n "${logrotate_logfile_compression_delay}" ]; then
+            new_log="${new_log}\n  ${logrotate_logfile_compression_delay}"
+          fi
+          if [ -n "${logrotate_interval}" ]; then
+            new_log="${new_log}\n  ${logrotate_interval}"
+          fi
+          if [ -n "${logrotate_size}" ]; then
+            new_log="${new_log}\n  ${logrotate_size}"
+          fi
+          if [ -n "${LOGROTATE_DATEFORMAT}" ]; then
+            new_log="${new_log}\n  dateext\n  dateformat ${LOGROTATE_DATEFORMAT}"
+          fi
+          new_log="${new_log}\n}"
+          echo "Inserting new ${f} in alphabetic order to /usr/bin/logratate.d/logrotate.conf"
+
+          insertInOrder $new_log $log_files /usr/bin/logrotate.d/logrotate.conf $last_line_no $d $_i
+        else
+          output "File has unknown user or group: ${f}, user: ${file_owner_user}, group: ${file_owner_group}"
+        fi
+      fi
+    else
+      remove $f /usr/bin/logrotate.d/logrotate.conf
+    fi
+  done
+
+  # remove config in /usr/bin/logrotate.d/logrotate.conf that no longer exists
+  configs=$(grep -E "^\s*${d}.*\{\s*$" /usr/bin/logrotate.d/logrotate.conf | cut -f1 -d' ')
+
+  for c in $configs; do
+    if [ ! -f "${c}" ]; then
+      remove $c /usr/bin/logrotate.d/logrotate.conf
+    fi
+  done
+
+  last_line_no=$(awk "
+    BEGIN {}
+      /^ *${_d}.*\{ *$/ {banner = 1; printf NR \" \"; print; next}
+      /^ *} *$/ {if (banner) {printf NR \" \"; print}; banner = 0}
+      {if (banner) {printf NR \" \"; print }}
+    END {}
+  " /usr/bin/logrotate.d/logrotate.conf)
+  last_line_no=$(($(echo "${last_line_no}" | tail -n 1 | cut -f1 -d' ') + 1))
+done
+
+# ----- Take all Log in Subfolders ------
+
+all_log_dirs=""
+
+if [ -n "${ALL_LOGS_DIRECTORIES}" ]; then
+  all_log_dirs=${ALL_LOGS_DIRECTORIES}
+fi
+
+for d in ${all_log_dirs}
+do
+  unset _d
+  _d=${_d//\//\\/}
+  _i=-1
+  log_files=$(find ${d} -type f);
+  for f in ${log_files};
+  do
+    ((_i++))
+    if [ -f "${f}" ]; then
+      if ! grep -q -E "^\s*${f}\s*\{\s*$" /usr/bin/logrotate.d/logrotate.conf; then
+        output "Found new file $f, Processing..."
+        file_owner_user=$(stat -c %U ${f})
+        file_owner_group=$(stat -c %G ${f})
+        if [ "$file_owner_user" != "UNKNOWN" ] && [ "$file_owner_group" != "UNKNOWN" ]; then
+          unset new_log
+          new_log="${f} {"
+          new_log="${new_log}\n  su ${file_owner_user} ${file_owner_group}"
+          new_log="${new_log}\n  copytruncate"
+          new_log="${new_log}\n  rotate ${logrotate_copies}"
+          new_log="${new_log}\n  missingok"
+          if [ -n "${logrotate_logfile_compression}" ]; then
+            new_log="${new_log}\n  ${logrotate_logfile_compression}"
+          fi
+          if [ -n "${logrotate_logfile_compression_delay}" ]; then
+            new_log="${new_log}\n  ${logrotate_logfile_compression_delay}"
+          fi
+          if [ -n "${logrotate_interval}" ]; then
+            new_log="${new_log}\n  ${logrotate_interval}"
+          fi
+          if [ -n "${logrotate_size}" ]; then
+            new_log="${new_log}\n  ${logrotate_size}"
+          fi
+          if [ -n "${LOGROTATE_DATEFORMAT}" ]; then
+            new_log="${new_log}\n  dateext\n  dateformat ${LOGROTATE_DATEFORMAT}"
+          fi
+          new_log="${new_log}\n}"
+          echo "Inserting new ${f} in alphabetic order to /usr/bin/logratate.d/logrotate.conf"
+
+          insertInOrder $new_log $log_files /usr/bin/logrotate.d/logrotate.conf $last_line_no $d $_i
+        else
+          output "File has unknown user or group: ${f}, user: ${file_owner_user}, group: ${file_owner_group}"
+        fi
+      fi
+    else
+      remove $f /usr/bin/logrotate.d/logrotate.conf
+    fi
+  done
+
+  # remove config in /usr/bin/logrotate.d/logrotate.conf that no longer exists
+  configs=$(grep -E "^\s*${d}.*\{\s*$" /usr/bin/logrotate.d/logrotate.conf | cut -f1 -d' ')
+
+  for c in $configs; do
+    if [ ! -f "${c}" ]; then
+      remove $c /usr/bin/logrotate.d/logrotate.conf
+    fi
+  done
+
+  last_line_no=$(awk "
+    BEGIN {}
+      /^ *${_d}.*\{ *$/ {banner = 1; printf NR \" \"; print; next}
+      /^ *} *$/ {if (banner) {printf NR \" \"; print}; banner = 0}
+      {if (banner) {printf NR \" \"; print }}
+    END {}
+  " /usr/bin/logrotate.d/logrotate.conf)
+  last_line_no=$(($(echo "${last_line_no}" | tail -n 1 | cut -f1 -d' ') + 1))
+done


### PR DESCRIPTION
# New Feature - Keep logrotate.conf up to date

## Overview on changes
added a new bash script `/usr/bin/logrotate.d/update-logrotate.sh`
modified `/usr/bin/logrotate.d/docker-entrypont.sh`'s cron job to always run this `update-logrotate.sh` script, before running the logrotate command

```bash
if [ "$1" = 'cron' ]; then
  /usr/bin/go-cron "${logrotate_croninterval}" /bin/bash -c "/usr/bin/logrotate.d/update-logrotate.sh; ${logrotate_cron_timetable}"
fi
```

## End Result
The `/usr/bin/logrotate.d/logrotate.conf`'s config will be up to date with the `log_dirs`'s log files (newly added log files' relevant `logrotate configs` will be added, removed logs files' relevant `logrotate configs` will be deleted)

## Test
* Copy the below content to a `run.sh` file
```bash
dir_name=$(cd `dirname $0` && pwd)

docker container run -it --rm --name logrotate-docker \
    -v ${dir_name}/containers:/var/lib/docker/containers \
    -v ${dir_name}/docker:/var/log/docker \
    -e "LOGS_DIRECTORIES=/var/lib/docker/containers /var/log/docker" \
    -e "LOGROTATE_COMPRESSION=compress" \
    -e "LOGROTATE_SIZE=50M" \
    -e "LOGROTATE_DATEFORMAT=-%Y%m%d" \
    -e "LOGROTATE_CRONSCHEDULE=* * * * * *" \
    shuliyey/logrotate
```
Note: `shuliyey/logrotate` is my forked version of the repo, can build the new image first and use the built image here

* Run the `run.sh` file
```
./run.sh
```

* On a new terminal session `docker exec -it logrotate-docker bash`

* Add/Remove some logs files in the relevant `LOGS_DIRECTORIES`. 

* Check content in `/usr/bin/logrotate.d/logrotate.conf` will be update correspondingly
