### PR TITLE
Allow setting user and group id at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,7 @@ ARG CONTAINER_UID=1000
 ARG CONTAINER_GID=1000
 
 # install dev tools
-RUN export CONTAINER_USER=logrotate && \
-    export CONTAINER_GROUP=logrotate && \
-    addgroup -g $CONTAINER_GID logrotate && \
-    adduser -u $CONTAINER_UID -G logrotate -h /usr/bin/logrotate.d -s /bin/bash -S logrotate && \
-    apk add --update \
+RUN apk add --update \
       tar \
       gzip \
       wget && \
@@ -39,7 +35,10 @@ ENV LOGROTATE_OLDDIR= \
     LOGROTATE_CRONSCHEDULE= \
     LOGROTATE_PARAMETERS= \
     LOGROTATE_STATUSFILE= \
-    LOG_FILE=
+    LOG_FILE= \
+# allow overriding at runtime
+    CONTAINER_UID=${CONTAINER_UID} \
+    CONTAINER_GID=${CONTAINER_GID}
 
 COPY docker-entrypoint.sh /usr/bin/logrotate.d/docker-entrypoint.sh
 COPY update-logrotate.sh /usr/bin/logrotate.d/update-logrotate.sh

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,6 +4,10 @@
 
 set -e
 
+# create user and group
+addgroup -g $CONTAINER_GID logrotate
+adduser -u $CONTAINER_UID -G logrotate -h /usr/bin/logrotate.d -s /bin/bash -S logrotate
+
 syslogger_tag=""
 
 if [ -n "${SYSLOGGER_TAG}" ]; then


### PR DESCRIPTION
From reusability perspective it would be convenient to be able to set user and group at container runtime, rather than having to rebuild the image. It is important when the process in another container, whose logs are being rotated, runs as a custom non-root user.
This can be accomplished by overriding `ARG` values with `ENV` (idea borrowed from [this SO answer](http://stackoverflow.com/a/41919137/1869360)). Obviously, in this case the step of creating the user/group must be dropped down to the entrypoint.

Usage:
```
docker run -d \
           -v /var/lib/docker/containers:/var/lib/docker/containers \
           -e "LOGS_DIRECTORIES=/var/lib/docker/containers" \
           -e CONTAINER_UID=9001 \
           -e CONTAINER_GID=9001 \
           --name logrotate \
           blacklabelops/logrotate
```
Verification
```
docker exec logrotate cat /etc/passwd | grep logrotate
logrotate:x:9001:9001:Linux User,,,:/usr/bin/logrotate.d:/bin/bash
```
Omitting extra variables in `docker run` results in the user being created with the default id.
```
docker run -d \
           -v /var/lib/docker/containers:/var/lib/docker/containers \
           -e "LOGS_DIRECTORIES=/var/lib/docker/containers" \
           --name logrotate \
           blacklabelops/logrotate
```
```
docker exec logrotate cat /etc/passwd | grep logrotate
logrotate:x:1000:1000:Linux User,,,:/usr/bin/logrotate.d:/bin/bash
```