### PR TITLE
Logrotate trying to send an email to "nomail"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .vagrant
 *.json
 *.log

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -88,7 +88,7 @@ touch /usr/bin/logrotate.d/logrotate.conf
 
 cat >> /usr/bin/logrotate.d/logrotate.conf <<EOF
 # deactivate mail
-mail nomail
+nomail
 
 # move the log files to another directory?
 ${logrotate_olddir}

--- a/update-logrotate.sh
+++ b/update-logrotate.sh
@@ -114,7 +114,7 @@ if [ ! -f /usr/bin/logrotate.d/logrotate.conf ]; then
 
   cat >> /usr/bin/logrotate.d/logrotate.conf <<EOF
 # deactivate mail
-mail nomail
+nomail
 
 # move the log files to another directory?
 ${logrotate_olddir}


### PR DESCRIPTION
The container logs with `LOGROTATE_PARAMETERS=d` are reporting that logrotate tried to send an email to `nomail`.

 `nomail` is a directive like `mail`, not a kind of `/dev/null` email address to send mail to:
https://linux.die.net/man/8/logrotate

So the correct way to disable mail is to simply have a line in `logrotate.conf` with just `nomail` instead of `mail nomail` like it was.
