### PR TITLE
Introduce tzdata, TZ environment variable will take effect (when tzdata is installed)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ RUN export CONTAINER_USER=logrotate && \
     apk add --update \
       tar \
       gzip \
-      wget && \
+      wget \
+      tzdata && \
     if  [ "${LOGROTATE_VERSION}" = "latest" ]; \
       then apk add logrotate ; \
       else apk add "logrotate=${LOGROTATE_VERSION}" ; \

--- a/README.md
+++ b/README.md
@@ -272,7 +272,6 @@ $ docker run -d \
 
 > You will be able to see cron output every minute in file logs/cron.log
 
-
 # Setting a Date Extension
 
 With Logrotate it is possible to split files and name them by the date they were generated when used with `LOGROTATE_CRONSCHEDULE`. By setting `LOGROTATE_DATEFORMAT` you will enable the Logrotate `dateext` option.
@@ -309,9 +308,26 @@ docker run -d \
   blacklabelops/logrotate
 ~~~~
 
+# Set Time Zone
+
+With Logrotate by default it logrotate logs in `UTC` time zone. It is possible to set time zone when used with `TZ`. By setting `TZ` (to a valid time zone) it will logrotate logs in the specified time zone.
+
+The default `TZ` is `""`, to set to different time zone. E.g `Australia/Melbourne`.
+
+Example:
+
+~~~~
+docker run -d \
+  -v /var/lib/docker/containers:/var/lib/docker/containers \
+  -v /var/log/docker:/var/log/docker \
+  -e "LOGS_DIRECTORIES=/var/lib/docker/containers /var/log/docker" \
+  -e "TZ=Australia/Melbourne" \
+  blacklabelops/logrotate
+~~~~
+
 ## Used in Kubernetes
 
-When we run container in Kubernetes, we can use the logrotate container to rotate the logs. As we create 
+When we run container in Kubernetes, we can use the logrotate container to rotate the logs. As we create
 
 an DaemonSet in cluster ,we can deploy an logrotate container in every nodes of the cluster.
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ $ docker run -d \
   blacklabelops/logrotate
 ~~~~
 
+> This will logrotate any logfile(s) under /var/lib/docker/containers, /var/log/docker (or subdirectories of them).
+
 # Customize Log File Ending
 
 You can define the file endings fluentd will attach to. The container will by default crawl for
@@ -97,6 +99,8 @@ $ docker run -d \
   blacklabelops/logrotate
 ~~~~
 
+> This will logrotate logfile(s) on hourly basis.
+
 # Set the Number of Rotations
 
 The default number of rotations is five. Further rotations will delete old logfiles. You
@@ -135,6 +139,8 @@ $ docker run -d \
   blacklabelops/logrotate
 ~~~~
 
+> This will logrotate when logfile(s) reaches 10M+.
+
 # Set Log File compression
 
 The default logrotate setting is `nocompress`. In order to enable logfile compression
@@ -150,6 +156,8 @@ $ docker run -d \
   -e "LOGROTATE_COMPRESSION=compress" \
   blacklabelops/logrotate
 ~~~~
+
+> This will compress the logrotated logs.
 
 # Set the Output directory
 
@@ -187,6 +195,8 @@ $ docker run -d \
   blacklabelops/logrotate
 ~~~~
 
+> This will logrotate on go-cron schedule "* * * * * *" (every second).
+
 # Log and View the Logrotate Output
 
 You can specify a logfile for the periodical logrotate execution. The file
@@ -206,7 +216,7 @@ $ docker run -d \
   blacklabelops/logrotate
 ~~~~
 
-> You will be able to see logrotate output every minute in file logs/logrotatecron.log
+> You will be able to see logrotate output every minute in file logs/logrotatecron.log.
 
 # Logrotate Commandline Parameters
 
@@ -270,11 +280,11 @@ $ docker run -d \
   blacklabelops/logrotate
 ~~~~
 
-> You will be able to see cron output every minute in file logs/cron.log
+> You will be able to see cron output every minute in file logs/cron.log.
 
 # Setting a Date Extension
 
-With Logrotate it is possible to split files and name them by the date they were generated when used with `LOGROTATE_CRONSCHEDULE`. By setting `LOGROTATE_DATEFORMAT` you will enable the Logrotate `dateext` option.
+With Logrotate it is possible to split files and name them by the date they were generated when used with `LOGROTATE_DATEFORMAT`. By setting `LOGROTATE_DATEFORMAT` you will enable the Logrotate `dateext` option.
 
 The default Logrotate format is `-%Y%m%d`, to enable the defaults `LOGROTATE_DATEFORMAT` should be set to this.
 
@@ -290,6 +300,8 @@ $ docker run -d \
   -e "LOGROTATE_DATEFORMAT=-%Y%m%d" \
   blacklabelops/logrotate
 ~~~~
+
+> This will set logrotate to split files and name them by date format -%Y%m%d.
 
 # Disable Auto Update
 
@@ -308,6 +320,8 @@ docker run -d \
   blacklabelops/logrotate
 ~~~~
 
+> This will disable logrotate configuration file update (when logrotate action is triggering).
+
 # Set Time Zone
 
 With Logrotate by default it logrotate logs in `UTC` time zone. It is possible to set time zone when used with `TZ`. By setting `TZ` (to a valid time zone) it will logrotate logs in the specified time zone.
@@ -324,6 +338,8 @@ docker run -d \
   -e "TZ=Australia/Melbourne" \
   blacklabelops/logrotate
 ~~~~
+
+> This will logrotate in Australia/Melbourne time zone.
 
 ## Used in Kubernetes
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ $ docker run -d \
   blacklabelops/logrotate
 ~~~~
 
-> This will logrotate on go-cron schedule "* * * * * *" (every second).
+> This will logrotate on go-cron schedule \* \* \* \* \* \* (every second).
 
 # Log and View the Logrotate Output
 


### PR DESCRIPTION
# Introduce TZ (Time Zone)

## Overview on changes
updated `Dockerfile` to install `tzdata` on build, this allows `TZ` environment variable to take effect when starting the docker container

```Dockerfile
diff --git a/Dockerfile b/Dockerfile
index bfe52de..bc79e49 100644
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ RUN export CONTAINER_USER=logrotate && \
     apk add --update \
       tar \
       gzip \
-      wget && \
+      wget \
+      tzdata && \
     if  [ "${LOGROTATE_VERSION}" = "latest" ]; \
       then apk add logrotate ; \
       else apk add "logrotate=${LOGROTATE_VERSION}" ; \
```

## End Result
When `TZ` environment is specified (to a valid time zone), the logrotate container, will logrotate the logs in the specified time zone

## Test
* Copy the below content to a `run.sh` file
```bash
dir_name=$(cd `dirname $0` && pwd)

docker container run -it --rm --name logrotate-docker \
    -v ${dir_name}/containers:/var/lib/docker/containers \
    -v ${dir_name}/docker:/var/log/docker \
    -e "LOGS_DIRECTORIES=/var/lib/docker/containers /var/log/docker" \
    -e "LOGROTATE_COMPRESSION=compress" \
    -e "LOGROTATE_SIZE=50M" \
    -e "LOGROTATE_DATEFORMAT=-%Y%m%d" \
    -e "TZ=Australia/Melbourne" \
    shuliyey/logrotate:feature_tzdata
```
Note: `shuliyey/logrotate` is my forked version of the repo, can build the new image first and use the built image here

* Run the `run.sh` file
```
./run.sh
```

* On a new terminal session `docker exec -it logrotate-docker bash`

* Check time using `date`, the time should be in the specified time zone
```bash
| => docker exec -it logrotate-docker bash
bash-4.3# date
Mon Oct 30 22:31:35 AEDT 2017
```

**Extra note**: the difference in behaviour without the `tzdata` (installed), below is an example
```bash
| => docker run -it --rm alpine ash
/ # date
Mon Oct 30 10:11:02 UTC 2017
/ # export TZ=Australia/Melbourne
/ # date
Mon Oct 30 10:11:11 GMT 2017
/ # apk add --update tzdata
fetch http://dl-cdn.alpinelinux.org/alpine/v3.6/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.6/community/x86_64/APKINDEX.tar.gz
(1/1) Installing tzdata (2017a-r0)
Executing busybox-1.26.2-r5.trigger
OK: 7 MiB in 12 packages
/ # date
Mon Oct 30 22:27:47 AEDT 2017
```
