### PR TITLE
Add options for delaycompress and rotation handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,42 @@ $ docker run -d \
 
 > This will compress the logrotated logs.
 
+## Turn Off Log File delaycompress
+
+When compression is turned on, delaycompress will be set by default. To turn this off,
+set the environment variable `LOGROTATE_DELAYCOMPRESS` to `false`.
+
+Example:
+~~~~
+$ docker run -d \
+  -v /var/lib/docker/containers:/var/lib/docker/containers \
+  -v /var/log/docker:/var/log/docker \
+  -e "LOGS_DIRECTORIES=/var/lib/docker/containers /var/log/docker" \
+  -e "LOGROTATE_COMPRESSION=compress" \
+  -e "LOGROTATE_DELAYCOMPRESS=false" \
+  blacklabelops/logrotate
+~~~~
+
+> This will compress all logrotated logs, including the most recent one.
+
+## Set logrotate mode
+
+By default, logrotate will use copytruncate mode to create a new rotated file, however
+certain log collection applications won't work properly with this configuration. To use a different
+option, such as `create <mode> <owner> <group>`, set the environment variable `LOGROTATE_MODE`.
+
+Example:
+~~~~
+$ docker run -d \
+  -v /var/lib/docker/containers:/var/lib/docker/containers \
+  -v /var/log/docker:/var/log/docker \
+  -e "LOGS_DIRECTORIES=/var/lib/docker/containers /var/log/docker" \
+  -e "LOGROTATE_MODE=create 0644"
+  blacklabelops/logrotate
+~~~~
+
+> This will rename the current log file, and create a new one in its place
+
 ## Set the Output directory
 
 By default, logrotate will rotate logs in their respective directories. You can

--- a/logrotate.sh
+++ b/logrotate.sh
@@ -45,13 +45,20 @@ function resolveSysloggerCommand() {
   fi
 }
 
+logrotate_mode="copytruncate"
+function resolveLogrotateMode() {
+  if [ -n "${LOGROTATE_MODE}" ]; then
+    logrotate_mode="${LOGROTATE_MODE}"
+  fi
+}
+
 logrotate_logfile_compression="nocompress"
 logrotate_logfile_compression_delay=""
 
 function resolveLogfileCompression() {
   if [ -n "${LOGROTATE_COMPRESSION}" ]; then
     logrotate_logfile_compression=${LOGROTATE_COMPRESSION}
-    if [ ! "${logrotate_logfile_compression}" = "nocompress" ]; then
+    if [ ! "${logrotate_logfile_compression}" = "nocompress" ] && [ "${LOGROTATE_DELAYCOMPRESS}" != "false" ]; then
       logrotate_logfile_compression_delay="delaycompress"
     fi
   fi
@@ -101,6 +108,7 @@ logrotate_dateformat=${LOGROTATE_DATEFORMAT:-""}
 
 resolveSysloggerCommand
 resolveOldDir
+resolveLogrotateMode
 resolveLogfileCompression
 resolveLogrotateSize
 resolveLogrotateAutoupdate

--- a/logrotateConf.sh
+++ b/logrotateConf.sh
@@ -9,17 +9,17 @@ function createLogrotateConfigurationEntry() {
   local conf_copies="$4"
   local conf_logfile_compression="$5"
   local conf_logfile_compression_delay="$6"
-  local conf_logrotate_interval="$7"
-  local conf_logrotate_size="$8"
-  local conf_dateformat="$9"
-  local conf_minsize="${10}"
-  local conf_maxage="${11}"
-  local conf_prerotate="${12}"
-  local conf_postrotate="${13}"
+  local conf_logrotate_mode="$7"
+  local conf_logrotate_interval="$8"
+  local conf_logrotate_size="$9"
+  local conf_dateformat="${10}"
+  local conf_minsize="${11}"
+  local conf_maxage="${12}"
+  local conf_prerotate="${13}"
+  local conf_postrotate="${14}"
   local new_log=
   new_log=${file}" {"
   new_log=${new_log}"\n  su ${file_owner_user} ${file_owner_group}"
-  new_log=${new_log}"\n  copytruncate"
   new_log=${new_log}"\n  rotate ${conf_copies}"
   new_log=${new_log}"\n  missingok"
   if [ -n "${conf_logfile_compression}" ]; then
@@ -27,6 +27,9 @@ function createLogrotateConfigurationEntry() {
   fi
   if [ -n "${conf_logfile_compression_delay}" ]; then
     new_log=${new_log}"\n  ${conf_logfile_compression_delay}"
+  fi
+  if [ -n "${conf_logrotate_mode}" ]; then
+    new_log=${new_log}"\n  ${conf_logrotate_mode}"
   fi
   if [ -n "${conf_logrotate_interval}" ]; then
     new_log=${new_log}"\n  ${conf_logrotate_interval}"

--- a/logrotateCreateConf.sh
+++ b/logrotateCreateConf.sh
@@ -7,7 +7,7 @@ function handleSingleFile() {
   local file_owner_user=$(stat -c %U ${singleFile})
   local file_owner_group=$(stat -c %G ${singleFile})
   if [ "$file_owner_user" != "UNKNOWN" ] && [ "$file_owner_group" != "UNKNOWN" ]; then
-    local new_logrotate_entry=$(createLogrotateConfigurationEntry "${singleFile}" "${file_owner_user}" "${file_owner_group}" "${logrotate_copies}" "${logrotate_logfile_compression}" "${logrotate_logfile_compression_delay}" "${logrotate_interval}" "${logrotate_size}" "${logrotate_dateformat}" "${logrotate_minsize}" "${logrotate_maxage}" "${logrotate_prerotate}" "${logrotate_postrotate}")
+    local new_logrotate_entry=$(createLogrotateConfigurationEntry "${singleFile}" "${file_owner_user}" "${file_owner_group}" "${logrotate_copies}" "${logrotate_logfile_compression}" "${logrotate_logfile_compression_delay}" "${logrotate_mode}" "${logrotate_interval}" "${logrotate_size}" "${logrotate_dateformat}" "${logrotate_minsize}" "${logrotate_maxage}" "${logrotate_prerotate}" "${logrotate_postrotate}")
     echo "Inserting new ${singleFile} to /usr/bin/logrotate.d/logrotate.conf"
     insertConfigurationEntry "$new_logrotate_entry" "/usr/bin/logrotate.d/logrotate.conf"
   else


### PR DESCRIPTION
Allow delaycompress to be turned off, and give the option to use something besides copytruncate mode.

I'm working on setting up a Fluentd logging solution and needed something to handle logrotation. This project seems like a great way to go, just needed to be able to turn off `copytruncate` mode because Fluentd doesn't handle that properly (it tracks logs by inode and offset).

I probably will end up using delaycompress anyway, but I haven't completely decided yet and I figured the option to turn it off would be nice.

The defaults settings are unaffected by my changes. `LOGROTATE_DELAYCOMPRESS` must be explicitly set to `false` to turn it off, and `copytruncate` is the default when `LOGROTATE_MODE` is not set.