### PR TITLE
Don't crash if given directory doesn't exist

### DIFF
--- a/logrotateCreateConf.sh
+++ b/logrotateCreateConf.sh
@@ -48,7 +48,7 @@ IFS=$SAVEIFS
 
 for d in ${log_dirs}
 do
-  log_files=$(find ${d} -type f $LOGS_FILE_ENDINGS_INSTRUCTION)
+  log_files=$(find ${d} -type f $LOGS_FILE_ENDINGS_INSTRUCTION) || continue
   for f in ${log_files};
   do
     if [ -f "${f}" ]; then


### PR DESCRIPTION
Useful for a case I ran into where this container lives in multiple places, and the given list of directories might not exist everywhere.