### PR TITLE
Automagically create users/groups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ COPY update-logrotate.sh /usr/bin/logrotate.d/update-logrotate.sh
 COPY logrotate.sh /usr/bin/logrotate.d/logrotate.sh
 COPY logrotateConf.sh /usr/bin/logrotate.d/logrotateConf.sh
 COPY logrotateCreateConf.sh /usr/bin/logrotate.d/logrotateCreateConf.sh
+COPY userGroupCreator.sh /usr/bin/lograte.d/userGroupCreator.sh
 
 ENTRYPOINT ["/sbin/tini","--","/usr/bin/logrotate.d/docker-entrypoint.sh"]
 VOLUME ["/logrotate-status"]

--- a/logrotateConf.sh
+++ b/logrotateConf.sh
@@ -19,9 +19,15 @@ function createLogrotateConfigurationEntry() {
   local conf_postrotate="${14}"
   local new_log=
   new_log=${file}" {"
-  if [ "$file_user" != "UNKNOWN" ] && [ "$file_owner" != "UNKNOWN" ]; then
-    new_log=${new_log}"\n  su ${file_user} ${file_owner}"
+
+  if [ "$file_user" == "UNKNOWN" ] || [ "$file_owner" == "UNKNOWN" ]; then
+    bash /usr/bin/logrotate.d/userGroupCreator.sh "${file}"
+    # get new user/group
+    file_user=$(stat -c %U ${singleFile})
+    file_owner=$(stat -c %G ${singleFile})
   fi
+
+  new_log=${new_log}"\n  su ${file_user} ${file_owner}"
   new_log=${new_log}"\n  rotate ${conf_copies}"
   new_log=${new_log}"\n  missingok"
   if [ -n "${conf_logfile_compression}" ]; then

--- a/userGroupCreator.sh
+++ b/userGroupCreator.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+
+# DOCUMENTATION
+# logrotate won't work with 
+# a) files with unknown users
+# b) if unknown user, then the directory must have closed permissions
+# due to the nature of our containers, most of our users don't map to other containers
+# the ones that do map are accidental
+# due to writing all logs to a single directory, we need to keep the logging directory open
+# this script takes files and checks for UNKNOWN groups or users
+# and creates users/groups on-the-fly if needed
+# these users have no meaning and creating a new container will lead to new usernames
+
+declare -r LOG_FILE_PATH="${1}"
+
+set -e                      # exit all shells if script fails
+set -u                      # exit script if uninitialized variable is used
+set -o pipefail             # exit script if anything fails in pipe
+
+
+function createGroup(){
+    # create a new group assigned to the given file's gid
+    local -r file_path="${1}"
+
+    local -r gid="$( stat -c '%g' "${file_path}" )"
+    local -r group="fakegroup-$(date +%s)"
+    sleep 1 # allow date to lapse
+
+    addgroup \
+        -g "${gid}" \
+        -S "${group}"
+}
+
+
+function createUser(){
+    # create a new user assigned to the given file's uid
+    local -r file_path="${1}"
+
+    local -r uid="$( stat -c '%u' "${file_path}" )"
+    local -r user="fakeuser-$(date +%s)"
+    sleep 1 # allow date to lapse
+
+    adduser \
+        -S "${user}" \
+        -D \
+        -H \
+        -u "${uid}"
+}
+
+
+function processLogFile(){
+    # check the given file for an associated user and group
+    # if either an UNKNOWN group or user, a user and/or group is randomly generated
+    # with the uid/gid assigned to the file
+    local -r file_path="${1}"
+
+    local -r user="$( stat -c '%U' "${file_path}" )"
+    local -r group="$( stat -c '%G' "${file_path}" )"
+
+    if [[ "${group}" == 'UNKNOWN' ]]; then
+        createGroup "${file_path}" || true
+    fi
+
+    if [[ "${user}" == 'UNKNOWN' ]]; then
+        createUser "${file_path}"  || true
+    fi
+}
+
+
+#########################
+# MAIN ##################
+#########################
+
+function main(){
+    if [[ -f "${LOG_FILE_PATH}" ]]; then
+        processLogFile "${LOG_FILE_PATH}"
+    else
+        exit 1
+    fi
+}
+main
+
+
+


### PR DESCRIPTION
In reference to: https://github.com/blacklabelops/logrotate/issues/25



**Problem use case**

Say a given log file has no user/group mapping present in the `logrotate` container. `logrotate` will attempt to rotate the file as `root`. This action may fail if the directory's permissions containing the log file are too open.


**Why does this happen**

This is mostly a result of the isolation that Docker gives. Each running container in a stack may have a unique set of user/group ID mappings. As a result, if all container logs are written to disk in a single directory permissions must be fairly open. 

For example, if `logrotate` has the following `/etc/passwd`:
```
root:x:0:0
nobody:x:65534:65534
```

And say container `foobar` (running as user `bizzbatt`) has the following `/etc/passwd`:
```
root:x:0:0
bizzbatt:x:400:400
nobody:x:65534:65534
```

`foobar` will write logs to disk that are owned by `bizzbatt`.


`logrotate` will fail to find a user mapped to ID 400 and will attempt to rotate the log as `root`. This will also fail because the logging directory permissions are so open.


This issue is "solved" by the pull request. When adding a file to the logrotate configuration, it will create users and groups as needed for discovered log files without users and groups.

After running this script, `/etc/passwd` in logrotate may look like this:
```
root:x:0:0
fakeuser-1532375851:x:400: 400
nobody:x:65534:65534
```

Now logrotate can `su` as a the mapped user `fakeuser-1532375851`. If `logrotate` is removed and re-started a new set of user/group mappings would be created.
