### PR TITLE
Add regex option

### DIFF
--- a/logrotateCreateConf.sh
+++ b/logrotateCreateConf.sh
@@ -42,6 +42,15 @@ do
 done
 IFS=$SAVEIFS
 
+# Check if regex search is enabled
+if [ -n "${LOGS_FILE_REGEX}" ]; then
+  if [ "$COUNTER" -eq "0" ]; then
+    LOGS_FILE_ENDINGS_INSTRUCTION="-regex $LOGS_FILE_REGEX"
+  else
+    LOGS_FILE_ENDINGS_INSTRUCTION="$LOGS_FILE_ENDINGS_INSTRUCTION -o -regex $LOGS_FILE_REGEX"
+  fi
+fi
+
 for d in ${log_dirs}
 do
   log_files=$(find ${d} -type f $LOGS_FILE_ENDINGS_INSTRUCTION) || continue


### PR DESCRIPTION
Hi,
I found some log file(e.g. apache error log) pattern are not matched
the `".<log-ending>"` pattern. So I add `LOGS_DIRECTORIES` environment
variable to support regex feature.
For example, 
`-e "LOGS_DIRECTORIES=/var/log" -e "LOGS_FILE_REGEX=".\\+l.g""` 
will match A.log, B_log, C.lag in `/var/log/ directory`.